### PR TITLE
update supported react version

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
     "ts-react-toolbox": "^0.2.11"
   },
   "peerDependencies": {
-    "react": "^16.8.0",
-    "@types/react": "^16.8.0"
+    "react": "^16.8.0 || ^17.0.0",
+    "@types/react": "^16.8.0 || ^17.0.0"
   },
   "peerDependenciesMeta": {
     "@types/react": {


### PR DESCRIPTION
This is a follow-up for the previous PR: https://github.com/theKashey/react-clientside-effect/pull/3

We need to upgrade the entire dependency tree to make npm v7 happy