### PR TITLE
fix next.js warning for useLayoutEffect

### DIFF
--- a/src/useMergeRef.ts
+++ b/src/useMergeRef.ts
@@ -4,6 +4,8 @@ import { assignRef } from './assignRef';
 import { ReactRef } from './types';
 import { useCallbackRef } from './useRef';
 
+const useIsomorphicLayoutEffect = typeof window !== 'undefined' ? React.useLayoutEffect : React.useEffect;
+
 const currentValues = new WeakMap<any, ReactRef<any>[]>();
 
 /**
@@ -26,7 +28,7 @@ export function useMergeRefs<T>(refs: ReactRef<T>[], defaultValue?: T): React.Mu
   );
 
   // handle refs changes - added or removed
-  React.useLayoutEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     const oldValue = currentValues.get(callbackRef);
 
     if (oldValue) {


### PR DESCRIPTION
I recently updated to the latest version of this package and I get tons of warnings where useMergeQuery is used, in this PR I introduced a new custom hook for that file. got this hook from [https://usehooks-ts.com/react-hook/use-isomorphic-layout-effect](https://usehooks-ts.com/react-hook/use-isomorphic-layout-effect) 

The warning that I got:

> Warning: useLayoutEffect does nothing on the server, because its effect cannot be encoded into the server renderer's output format. This will lead to a mismatch between the initial, non-hydrated UI and the intended UI. To avoid this, useLayoutEffect should only be used in components that render exclusively on the client. See https://reactjs.org/link/uselayouteffect-ssr for common fixes.

This hook fixes this problem by switching between useEffect and useLayoutEffect following the execution environment.